### PR TITLE
opam file+detect plplotd vs plplot pkg-config name

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,30 @@
+opam-version: "1.2"
+name: "plplot"
+version: "dev"
+author : "Hezekiah M. Carty"
+maintainer: "Hezekiah M. Carty"
+homepage: "https://github.com/hcarty/ocaml-plplot"
+dev-repo: "git://github.com/hcarty/ocaml-plplot.git#master"
+bug-reports: "https://github.com/hcarty/ocaml-plplot/issues"
+
+build: [
+  ["ocaml" "setup.ml" "-configure"]
+  ["ocaml" "setup.ml" "-build"]
+]
+
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+
+remove: [
+ ["ocamlfind" "remove" "plplot"]
+]
+
+depends: [
+  "oasis" {build}
+]
+
+depexts: [
+  [["debian"] ["libplplot-dev"]]
+  [["ubuntu"] ["libplplot-dev"]]
+]


### PR DESCRIPTION
Provisional opam with depext specified for ubuntu systems. Also now detects whether "plplot" or "plplotd" is the correct pkg-config name.
