### PR TITLE
In some configurations gcc is passing incompatible pointer types that…

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -14,6 +14,7 @@
    :standard
    -g
    -O2
+   -Wno-error=incompatible-pointer-types
    (:include c_flags.sexp)))
  (c_library_flags
   :standard


### PR DESCRIPTION
… make the build fail, however the library seem to keep working as expected when the warning is ignored.

See https://github.com/hcarty/ocaml-plplot/issues/9
