### PR TITLE
Fix ocaml-plplot build for GCC >= 14 and unbreak Opam CI.

### DIFF
--- a/configure/discover.ml
+++ b/configure/discover.ml
@@ -10,6 +10,28 @@ int main()
 }
 |}
 
+(** Flags for compatibility with newer, less permissive versions of
+    GCC. *)
+let gcc_compat_cflags = ["-Wno-error=incompatible-pointer-types"]
+
+(** [cflag_supported ~c cflag] tests that [cflag] is accepted by the C
+    compiler in the Configurator context [c]. *)
+let cflag_supported ~c cflag =
+  let noop_test = "int main() { return 0; }\n" in
+  let result = C.c_test c noop_test ~c_flags:[cflag] ~link_flags:[] in
+  if result then Format.eprintf "C compiler accepts flag: %s\n" cflag ;
+  result
+
+(** [compat_cflags ~c] detects any relevant compatibility flags
+    accepted by the C compiler in the Configurator context [c]. Note
+    that with some compiler versions, a flag may specify behavior
+    that's enabled by default. *)
+let compat_cflags ~c =
+  let filter_cflags = List.filter (cflag_supported ~c) in
+  match C.ocaml_config_var c "c_compiler" with
+  | Some "gcc" -> filter_cflags gcc_compat_cflags
+  | _ -> []
+
 let () =
   C.main ~name:"plplot" (fun c ->
       let conf =
@@ -26,14 +48,14 @@ let () =
             | Some conf -> conf
           end 
       in
+      let c_flags = conf.cflags @ compat_cflags ~c in
       if not
         @@ C.c_test
           c
           plplot_test
-          ~c_flags:conf.cflags
+          ~c_flags
           ~link_flags:conf.libs
       then
-        failwith "No valid installation of plplot or plplotd found."
-      else
-        C.Flags.write_sexp "c_flags.sexp" conf.cflags;
+        failwith "No valid installation of plplot or plplotd found." ;
+      C.Flags.write_sexp "c_flags.sexp" c_flags;
       C.Flags.write_sexp "c_library_flags.sexp" conf.libs)


### PR DESCRIPTION
New versions of GCC promote several warnings to errors by default. In this repository, code included from the underlying plplot C library triggers the error [incompatible-pointer-types](https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types).

This issue is currently breaking ocaml-plplot tests in opam's CI; for more info please see https://github.com/ocaml/opam-repository/issues/28095.

The GCC behavior change can be reversed by adding an extra flag, but we must take care to verify that the C compiler in the build environment is new enough to recognize the flag. This PR adds the detection logic via Dune Configurator.

In addition, the PR fixes one benign logic bug at the bottom of the same module. When the Configurator fails to find the plplot library dependency, it should not write either `c_flags.sexp` or `c_library_flags.sexp` to disk. The existing code accomplishes this, but in a roundabout way: the call that writes `c_library_flags.sexp` is beyond the end of the if/then/else block and happens even in the failure case (or rather, it *would* happen if the call to `failwith` did not make this code path inaccessible). Removing the `else` arm of the block and just continuing the sequence of statements makes the intent clearer. 

Testing:

In a hermetic sandbox environment, ocaml-plplot was compiled via opam using a recent GCC (v14) and a less recent one (v10).

Additional tests using Clang (v16 and v20) showed that no new flags are needed in these cases.